### PR TITLE
Prime locants

### DIFF
--- a/cdk/pom.xml
+++ b/cdk/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>centres</artifactId>
         <groupId>com.simolecule.centres</groupId>
-        <version>1.4</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cdk/src/main/java/com/simolecule/centres/CdkLabeller.java
+++ b/cdk/src/main/java/com/simolecule/centres/CdkLabeller.java
@@ -121,9 +121,22 @@ public final class CdkLabeller extends Labeller<IAtom, IBond> {
         case IStereoElement.OC: {
           org.openscience.cdk.stereo.Octahedral ocSe
                   = ((org.openscience.cdk.stereo.Octahedral) se).normalize();
-          configs.add(new Octahedral<IAtom, IBond>(ocSe.getFocus(),
-                                                   ocSe.getCarriers()
-                                                       .toArray(new IAtom[6])));
+          IAtom focus = ocSe.getFocus();
+
+          List<IAtom> carriers = ocSe.getCarriers();
+
+          // actually square planar!
+          if (focus.getImplicitHydrogenCount() == 0 &&
+              focus.getBondCount() == 4 &&
+              carriers.get(0).equals(focus) && carriers.get(5).equals(focus)) {
+            configs.add(new SquarePlanar<>(focus,
+                                           ocSe.getCarriers().subList(1,5)
+                                               .toArray(new IAtom[6])));
+          } else {
+            configs.add(new Octahedral<IAtom, IBond>(focus,
+                                                     ocSe.getCarriers()
+                                                         .toArray(new IAtom[6])));
+          }
         }
         break;
         case IStereoElement.SP: {

--- a/cdk/src/test/java/com/simolecule/centres/InorganicConfigTest.java
+++ b/cdk/src/test/java/com/simolecule/centres/InorganicConfigTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 John Mayfield
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.simolecule.centres;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openscience.cdk.exception.InvalidSmilesException;
+import org.openscience.cdk.interfaces.IAtom;
+import org.openscience.cdk.interfaces.IAtomContainer;
+import org.openscience.cdk.interfaces.IChemObjectBuilder;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
+import org.openscience.cdk.smiles.SmilesParser;
+
+/**
+ * Currently these are omitted from the regression set as often a toolkit will
+ * not handle inorganic configurations.
+ */
+public class InorganicConfigTest {
+
+  static String getConfig(String smi) {
+    IChemObjectBuilder bldr = SilentChemObjectBuilder.getInstance();
+    SmilesParser smipar = new SmilesParser(bldr);
+    IAtomContainer mol;
+    try {
+      mol = smipar.parseSmiles(smi);
+    } catch (InvalidSmilesException e) {
+      return null;
+    }
+    CdkLabeller.label(mol);
+    StringBuilder configs = new StringBuilder();
+    for (IAtom atom : mol.atoms()) {
+      Object property = atom.getProperty("conf.index");
+      if (property != null) {
+        configs.append(property);
+      }
+    }
+    return configs.toString();
+  }
+
+  static void assertConfig(String smi, String config) {
+    Assert.assertEquals(config, getConfig(smi));
+  }
+
+  @Test
+  public void testSimpleSP() {
+    assertConfig("[Pt@SP1](Cl)(Cl)([NH3])[NH3]", "SP-4-2");
+    assertConfig("[Pt@SP2](Cl)(Cl)([NH3])[NH3]", "SP-4-1");
+    assertConfig("[Pt@SP3](Cl)(Cl)([NH3])[NH3]", "SP-4-2");
+  }
+
+  @Test
+  public void testSimpleOCasSP() {
+    assertConfig("[Pt@OH25](Cl)(Cl)([NH3])[NH3]", "SP-4-2");
+    assertConfig("[Pt@OH27](Cl)(Cl)([NH3])[NH3]", "SP-4-1");
+  }
+
+  @Test
+  public void testTiedSP() {
+    assertConfig("[Pt@SP1](Cl)(Cl)([N]1=CC=CC=C1)[N]#CC", "SP-4-3");
+    assertConfig("[Pt@SP2](Cl)(Cl)([N]1=CC=CC=C1)[N]#CC", "SP-4-1");
+    assertConfig("[Pt@SP3](Cl)(Cl)([N]1=CC=CC=C1)[N]#CC", "SP-4-2");
+  }
+
+  @Test
+  public void testBisBidentateSP() {
+    assertConfig("[Ru@SP1]1(OCCO1)1(OCCO1)", "SP-4-1′");
+    assertConfig("[Ru@SP2]1(OCCO1)1(OCCO1)", "SP-4-1");
+    assertConfig("[Ru@SP3]1(OCCO1)1(OCCO1)", "SP-4-1′");
+  }
+
+  @Test
+  public void testBisBidentateOC() {
+    assertConfig("[Mo@OH1](C)(1SCCO1)(1SCCO1)[H]", "OC-6-1′2′-C");
+    assertConfig("[Mo@OH2](C)(1SCCO1)(1SCCO1)[H]", "OC-6-1′2′-A");
+  }
+
+  @Test
+  public void testBisBidentateTBPY() {
+    assertConfig("[Mo@TB1](C)(1SCCO1)1SCCO1", "TBPY-5-1′3-A");
+    assertConfig("[Mo@TB2](C)(1SCCO1)1SCCO1", "TBPY-5-1′3-C");
+  }
+
+  @Test
+  public void testTrisBidentateOC() {
+    assertConfig("[W@]123(OCCO1)(OCCO2)OCCO3 Δ", "OC-6-1ʺ1′-A");
+    assertConfig("O=C1O[Fe@OH12-3]23(OC(C(O3)=O)=O)(OC(C(O2)=O)=O)OC1=O Δ", "OC-6-1ʺ1′-A");
+    assertConfig("Cl[Co@OH29+]12([NH2]CC[NH2]2)([NH2]CC[NH2]1)Cl Δ-cis", "OC-6-2′2-A");
+
+    assertConfig("[W@@]123(OCCO1)(OCCO2)OCCO3 Λ", "OC-6-1ʺ1′-C");
+    assertConfig("O=C1O[Fe@OH13-3]23(OC(C(O3)=O)=O)(OC(C(O2)=O)=O)OC1=O Λ", "OC-6-1ʺ1′-C");
+    assertConfig("Cl[Co@OH26+]12([NH2]CC[NH2]2)([NH2]CC[NH2]1)Cl Λ-cis", "OC-6-2′2-C");
+  }
+}

--- a/cdk/src/test/java/com/simolecule/centres/InorganicConfigTest.java
+++ b/cdk/src/test/java/com/simolecule/centres/InorganicConfigTest.java
@@ -62,7 +62,7 @@ public class InorganicConfigTest {
 
   static void assertConfig(String smi, String config) {
     Assert.assertEquals("Incorrect config", config, getConfig(smi));
-    // System.err.println(smi + " " + getConfig(smi));
+     System.err.println(smi + " " + getConfig(smi));
   }
 
   @Test
@@ -108,14 +108,15 @@ public class InorganicConfigTest {
 
   @Test
   public void testBisBidentateSPY5() {
-    assertConfig("[Mo@OH1](C)(1SCCO1)1SCCO1", "SPY-5-1′3");
-    assertConfig("[Mo@OH2](C)(1SCCO1)1SCCO1", "SPY-5-1′3");
-    assertConfig("[Mo@OH25](C)(1SCCO1)1SCCO1", "SPY-5-31′");
-    assertConfig("[Mo@OH26](C)(1SCCO1)1SCCO1", "SPY-5-32′");
-    assertConfig("[Mo@OH1](C)(1OCCO1)1OCCO1", "SPY-5-1′2");
-    assertConfig("[Mo@OH2](C)(1OCCO1)1OCCO1", "SPY-5-1′2");
-    assertConfig("[Mo@OH25](C)(1OCCO1)1OCCO1", "SPY-5-21′");
-    assertConfig("[Mo@OH26](C)(1OCCO1)1OCCO1", "SPY-5-21′");
+    assertConfig("[Mo@OH1](C)(1SCCO1)1SCCO1", "SPY-5-1′3-A");
+    assertConfig("[Mo@OH2](C)(1SCCO1)1SCCO1", "SPY-5-1′3-C");
+    assertConfig("[Mo@OH25](C)(1SCCO1)1SCCO1", "SPY-5-31′-A");
+    assertConfig("[Mo@OH25](C)(1OCCS1)1OCCS1", "SPY-5-31′-C");
+    assertConfig("[Mo@OH26](C)(1SCCO1)1SCCO1", "SPY-5-32′-C");
+    assertConfig("[Mo@OH1](C)(1OCCO1)1OCCO1", "SPY-5-1′2-A");
+    assertConfig("[Mo@OH2](C)(1OCCO1)1OCCO1", "SPY-5-1′2-C");
+    assertConfig("[Mo@OH25](C)(1OCCO1)1OCCO1", "SPY-5-21′-A");
+    assertConfig("[Mo@OH26](C)(1OCCO1)1OCCO1", "SPY-5-21′-A");
   }
 
   @Test

--- a/cdk/src/test/java/com/simolecule/centres/InorganicConfigTest.java
+++ b/cdk/src/test/java/com/simolecule/centres/InorganicConfigTest.java
@@ -61,7 +61,8 @@ public class InorganicConfigTest {
   }
 
   static void assertConfig(String smi, String config) {
-    Assert.assertEquals(config, getConfig(smi));
+    Assert.assertEquals("Incorrect config", config, getConfig(smi));
+    // System.err.println(smi + " " + getConfig(smi));
   }
 
   @Test
@@ -75,6 +76,14 @@ public class InorganicConfigTest {
   public void testSimpleOCasSP() {
     assertConfig("[Pt@OH25](Cl)(Cl)([NH3])[NH3]", "SP-4-2");
     assertConfig("[Pt@OH27](Cl)(Cl)([NH3])[NH3]", "SP-4-1");
+  }
+
+  @Test
+  public void testSimpleOC() {
+    assertConfig("[Co@OH1](Cl)(Cl)([NH3])([NH3])([NH3])[NH3]", "OC-6-22");
+    assertConfig("[Co@OH25](Cl)(Cl)([NH3])([NH3])([NH3])[NH3]", "OC-6-12");
+    assertConfig("[Co@OH1](Cl)(Cl)(Cl)(Cl)([NH3])[NH3]", "OC-6-22");
+    assertConfig("[Co@OH12](Cl)(Cl)(Cl)(Cl)([NH3])[NH3]", "OC-6-11");
   }
 
   @Test
@@ -95,6 +104,18 @@ public class InorganicConfigTest {
   public void testBisBidentateOC() {
     assertConfig("[Mo@OH1](C)(1SCCO1)(1SCCO1)[H]", "OC-6-1′2′-C");
     assertConfig("[Mo@OH2](C)(1SCCO1)(1SCCO1)[H]", "OC-6-1′2′-A");
+  }
+
+  @Test
+  public void testBisBidentateSPY5() {
+    assertConfig("[Mo@OH1](C)(1SCCO1)1SCCO1", "SPY-5-1′3");
+    assertConfig("[Mo@OH2](C)(1SCCO1)1SCCO1", "SPY-5-1′3");
+    assertConfig("[Mo@OH25](C)(1SCCO1)1SCCO1", "SPY-5-31′");
+    assertConfig("[Mo@OH26](C)(1SCCO1)1SCCO1", "SPY-5-32′");
+    assertConfig("[Mo@OH1](C)(1OCCO1)1OCCO1", "SPY-5-1′2");
+    assertConfig("[Mo@OH2](C)(1OCCO1)1OCCO1", "SPY-5-1′2");
+    assertConfig("[Mo@OH25](C)(1OCCO1)1OCCO1", "SPY-5-21′");
+    assertConfig("[Mo@OH26](C)(1OCCO1)1OCCO1", "SPY-5-21′");
   }
 
   @Test

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.simolecule.centres</groupId>
         <artifactId>centres</artifactId>
-        <version>1.4</version>
+        <version>1.5-SNAPSHOT</version>
     </parent>
 
     <name>centres-core</name>

--- a/core/src/main/java/com/simolecule/centres/Node.java
+++ b/core/src/main/java/com/simolecule/centres/Node.java
@@ -240,6 +240,8 @@ public final class Node<A, B> {
         return "Br";
       case 9:
         return "F";
+      case 16:
+        return "S";
       default:
         return "#" + elem;
     }

--- a/core/src/main/java/com/simolecule/centres/config/CipRank.java
+++ b/core/src/main/java/com/simolecule/centres/config/CipRank.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 John Mayfield
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.simolecule.centres.config;
+
+import java.util.Objects;
+
+/**
+ * The class captures a CIP-rank and an optional prime indication. This is
+ * useful for inorganic configurations with bidentate and tridentate ligands.
+ */
+final class CipRank implements Comparable<CipRank> {
+  private final int rank;
+  private final int prime;
+
+  CipRank(int rank, Integer prime) {
+    this.rank = rank;
+    this.prime = prime != null ? prime : 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    CipRank rank = (CipRank) o;
+    return this.rank == rank.rank && prime == rank.prime;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rank, prime);
+  }
+
+  @Override
+  public int compareTo(CipRank o) {
+    int cmp = Integer.compare(rank, o.rank);
+    if (cmp != 0)
+      return cmp;
+    return Integer.compare(prime, o.prime);
+  }
+
+  @Override
+  public String toString() {
+    switch (prime) {
+      case 1:
+        return rank + "′";
+      case 2:
+        return rank + "ʺ";
+      case 3:
+        return rank + "‴";
+      case 4:
+        return rank + "⁗";
+      case 0:
+        return Integer.toString(rank);
+      default:
+        return rank + "?";
+    }
+  }
+}

--- a/core/src/main/java/com/simolecule/centres/config/Configuration.java
+++ b/core/src/main/java/com/simolecule/centres/config/Configuration.java
@@ -34,8 +34,11 @@ import com.simolecule.centres.Node;
 import com.simolecule.centres.rules.SequenceRule;
 
 import java.lang.reflect.Array;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public abstract class Configuration<A, B> {
 
@@ -217,5 +220,45 @@ public abstract class Configuration<A, B> {
                           Digraph<A, B> digraph,
                           SequenceRule<A, B> comp) {
     return Descriptor.Unknown;
+  }
+
+  protected void assignPrimeLocants(List<List<Edge<A, B>>> parts,
+                                    Map<A, Integer> primes) {
+
+    // note this procedure is only for bidentate ligands, assigning primes
+    // to high order dentate ligands is a bit more complicated
+
+    BaseMol<A,B> mol = digraph.getMol();
+    for (List<Edge<A,B>> part : parts) {
+      if (part.size() > 1) {
+        boolean assigned = false;
+        int primeNum = 0;
+        for (Edge<A, B> abEdge : part) {
+          Node<A, B> atom = abEdge.getEnd();
+          if (mol.isInRing(abEdge.getBond()) &&
+              !primes.containsKey(atom.getAtom())) {
+            assigned = true;
+            Deque<Edge<A, B>> queue = new ArrayDeque<>();
+            queue.add(abEdge);
+            while (!queue.isEmpty()) {
+              Edge<A, B> e = queue.poll();
+              if (e.getEnd().getAtom() != null) {
+                primes.put(e.getEnd().getAtom(), primeNum);
+                queue.addAll(e.getEnd().getOutEdges());
+              }
+            }
+            primeNum++;
+          }
+        }
+
+        if (assigned) {
+          part.sort((o1, o2) -> {
+            Integer o1prime = primes.get(o1.getEnd().getAtom());
+            Integer o2prime = primes.get(o2.getEnd().getAtom());
+            return Integer.compare(o1prime, o2prime);
+          });
+        }
+      }
+    }
   }
 }

--- a/core/src/main/java/com/simolecule/centres/config/Octahedral.java
+++ b/core/src/main/java/com/simolecule/centres/config/Octahedral.java
@@ -35,6 +35,7 @@ import com.simolecule.centres.rules.Priority;
 import com.simolecule.centres.rules.SequenceRule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,15 +146,13 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
     throw new IllegalArgumentException();
   }
 
-  private boolean hasConfiguration(List<List<Edge<A, B>>> parts, Map<A,Integer> primes) {
-    if (parts.size() > 2 ||
-        parts.size() == 2 && parts.get(0).size() != 1 && parts.get(0).size() != 5) {
-      return true;
-    }
+  private boolean hasOctahedralConfig(List<List<Edge<A, B>>> parts, Map<A,Integer> primes) {
 
     // check prime partitions
+    int total = 0;
     int numParts = parts.size();
     for (List<Edge<A,B>> part : parts) {
+      total += part.size();
       for (int i=1; i<part.size(); i++) {
         Integer primeA = primes.get(part.get(i-1).getEnd().getAtom());
         Integer primeB = primes.get(part.get(i).getEnd().getAtom());
@@ -162,18 +161,49 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
       }
     }
 
+    if (total != 6)
+      return false; // not OC-6!
+
+    if (numParts > 2 ||
+        parts.size() == 2 &&
+        ((parts.get(0).size() != 1 && parts.get(0).size() != 5) ||
+         (parts.get(0).size() != 5 && parts.get(0).size() != 1))) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private boolean hasSPY5(List<List<Edge<A, B>>> parts, Map<A,Integer> primes) {
+
+    // check prime partitions
+    int total = 0;
+    int numParts = parts.size();
+    for (List<Edge<A,B>> part : parts) {
+      total += part.size();
+      for (int i=1; i<part.size(); i++) {
+        Integer primeA = primes.get(part.get(i-1).getEnd().getAtom());
+        Integer primeB = primes.get(part.get(i).getEnd().getAtom());
+        if (!Objects.equals(primeA, primeB))
+          numParts++;
+      }
+    }
+
+    if (total != 5)
+      return false; // not SPY-5!
+
     return numParts > 2;
   }
 
   private Descriptor label(Node<A, B> root, SequenceRule<A, B> comp) {
-    List<Edge<A, B>>       edges    = root.getEdges();
-    Priority               priority = comp.sort(root, edges);
+    List<Edge<A, B>> edges = root.getEdges();
+    Priority priority = comp.sort(root, edges);
     if (priority.wasWildcardFound())
       return Descriptor.Unknown;
-    List<List<Edge<A, B>>> parts    = comp.getSorter().getGroups(edges);
+    List<List<Edge<A, B>>> parts = comp.getSorter().getGroups(edges);
 
     // add on prime locants if not unique
-    Map<A,Integer> primes = new HashMap<>();
+    Map<A, Integer> primes = new HashMap<>();
 
     if (!priority.isUnique()) {
 
@@ -186,87 +216,112 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
       assignPrimeLocants(parts, primes);
     }
 
-    if (!hasConfiguration(parts, primes))
-      return Descriptor.ns; // maybe return unknown?
+    if (hasOctahedralConfig(parts, primes)) {
+      A fstAxisBeg = null;
+      CipRank fstAxisBegRank = null;
+      CipRank fstAxisEndRank = null;
+      CipRank sndAxisBegRank;
+      CipRank sndAxisEndRank;
+      CipRank thdAxisBegRank;
+      CipRank thdAxisEndRank;
 
-    A       fstAxisBeg = null;
-    CipRank fstAxisBegRank = null;
-    CipRank fstAxisEndRank = null;
-    CipRank sndAxisBegRank;
-    CipRank sndAxisEndRank;
-    CipRank thdAxisBegRank;
-    CipRank thdAxisEndRank;
-
-    // the first axis is select by starting from the highest priority ligand,
-    // if there are multiple we choose the axis going towards the lowest
-    // priority
-    for (Edge<A, B> edge : parts.get(0)) {
-      A   beg = edge.getEnd().getAtom();
-      A   end = findTransAtom(beg);
-      CipRank begRank = new CipRank(getPriorityNumber(parts, beg), primes.get(beg));
-      CipRank endRank = new CipRank(getPriorityNumber(parts, end), primes.get(end));
-      if (fstAxisBegRank != null && !begRank.equals(fstAxisBegRank))
-        break;
-      if (fstAxisEndRank == null ||
-          endRank.compareTo(fstAxisEndRank) > 0) {
-        fstAxisBegRank = begRank;
-        fstAxisEndRank = endRank;
-        fstAxisBeg = beg;
+      // the first axis is select by starting from the highest priority ligand,
+      // if there are multiple we choose the axis going towards the lowest
+      // priority
+      for (Edge<A, B> edge : parts.get(0)) {
+        A beg = edge.getEnd().getAtom();
+        A end = findTransAtom(beg);
+        CipRank begRank = new CipRank(getPriorityNumber(parts, beg), primes.get(beg));
+        CipRank endRank = new CipRank(getPriorityNumber(parts, end), primes.get(end));
+        if (fstAxisBegRank != null && !begRank.equals(fstAxisBegRank))
+          break;
+        if (fstAxisEndRank == null ||
+            endRank.compareTo(fstAxisEndRank) > 0) {
+          fstAxisBegRank = begRank;
+          fstAxisEndRank = endRank;
+          fstAxisBeg = beg;
+        }
       }
-    }
 
-    // get the ligands in the plan of the axis rotating counter-clockwise
-    List<CipRank> ccw_plane = new ArrayList<>(4);
-    for (A a : getPlane(fstAxisBeg)) {
-      CipRank r = new CipRank(getPriorityNumber(parts, a), primes.get(a));
-      ccw_plane.add(r);
-    }
-
-    // work out the second axis
-    int low = 0;
-    for (int i = 1; i < 4; i++) {
-      if (ccw_plane.get(i).compareTo(ccw_plane.get(low)) < 0) {
-        low = i;
-      } else if (ccw_plane.get(i).equals(ccw_plane.get(low)) &&
-                 ccw_plane.get((i + 2) % 4).compareTo(ccw_plane.get((low + 2) % 4)) > 0) {
-        low = i;
+      // get the ligands in the plan of the axis rotating counter-clockwise
+      List<CipRank> ccw_plane = new ArrayList<>(4);
+      for (A a : getPlane(fstAxisBeg)) {
+        CipRank r = new CipRank(getPriorityNumber(parts, a), primes.get(a));
+        ccw_plane.add(r);
       }
-    }
 
-    sndAxisBegRank = ccw_plane.get(low);
-    sndAxisEndRank = ccw_plane.get((low + 2) % 4);
-    thdAxisBegRank = ccw_plane.get((low + 1) % 4);
-    thdAxisEndRank = ccw_plane.get((low + 3) % 4);
+      // work out the second axis
+      int low = 0;
+      for (int i = 1; i < 4; i++) {
+        if (ccw_plane.get(i).compareTo(ccw_plane.get(low)) < 0) {
+          low = i;
+        } else if (ccw_plane.get(i).equals(ccw_plane.get(low)) &&
+                   ccw_plane.get((i + 2) % 4).compareTo(ccw_plane.get((low + 2) % 4)) > 0) {
+          low = i;
+        }
+      }
 
-    // suppress warnings
-    if (fstAxisEndRank == null)
-      return Descriptor.ns;
+      sndAxisBegRank = ccw_plane.get(low);
+      sndAxisEndRank = ccw_plane.get((low + 2) % 4);
+      thdAxisBegRank = ccw_plane.get((low + 1) % 4);
+      thdAxisEndRank = ccw_plane.get((low + 3) % 4);
 
-    // check if we need rotation and what is.
-    // If two axis are the same or if there is a symmetric axis we don't need
-    // a rotation
-    int cmp = 0;
-    if (isAsymmetric(fstAxisBegRank, fstAxisEndRank,
-                     sndAxisBegRank, sndAxisEndRank,
-                     thdAxisBegRank, thdAxisEndRank)) {
-      cmp = ccw_plane.get((low + 1) % 4).compareTo(ccw_plane.get((low + 4 - 1) % 4));
-      if (cmp == 0)
+      // suppress warnings
+      if (fstAxisEndRank == null)
+        return Descriptor.ns;
+
+      // check if we need rotation and what is.
+      // If two axis are the same or if there is a symmetric axis we don't need
+      // a rotation
+      int cmp = 0;
+      if (isAsymmetric(fstAxisBegRank, fstAxisEndRank,
+                       sndAxisBegRank, sndAxisEndRank,
+                       thdAxisBegRank, thdAxisEndRank)) {
         cmp = ccw_plane.get((low + 1) % 4).compareTo(ccw_plane.get((low + 4 - 1) % 4));
-      if (cmp == 0)
-        cmp = ccw_plane.get((low + 2) % 4).compareTo(ccw_plane.get((low + 4 - 2) % 4));
-    }
+        if (cmp == 0)
+          cmp = ccw_plane.get((low + 1) % 4).compareTo(ccw_plane.get((low + 4 - 1) % 4));
+        if (cmp == 0)
+          cmp = ccw_plane.get((low + 2) % 4).compareTo(ccw_plane.get((low + 4 - 2) % 4));
+      }
 
-    final String rotate;
-    if (cmp < 0)
-      rotate = "-A";
-    else if (cmp > 0)
-      rotate = "-C";
-    else
-      rotate = "";
+      final String rotate;
+      if (cmp < 0)
+        rotate = "-A";
+      else if (cmp > 0)
+        rotate = "-C";
+      else
+        rotate = "";
 
-    if (sndAxisEndRank != null) {
-      cache.put(getFocus(), "OC-6-" + fstAxisEndRank + sndAxisEndRank + rotate);
-      return Descriptor.OC_6;
+      if (sndAxisEndRank != null) {
+        cache.put(getFocus(), "OC-6-" + fstAxisEndRank + sndAxisEndRank + rotate);
+        return Descriptor.OC_6;
+      }
+    } else if (hasSPY5(parts, primes)) {
+      // double-check the missing ligand is in the first position
+      if (getCarriers()[0].equals(getFocus())) {
+
+        A axis = getCarriers()[5];
+        CipRank axisRank = new CipRank(getPriorityNumber(parts, axis), primes.get(axis));
+
+        // note we are upside down so the plane is clockwise not anti-clockwise
+        CipRank sndAxisBeg = null;
+        CipRank sndAxisEnd = null;
+        for (int i=1; i<5; i++) {
+          A beg = getCarriers()[i];
+          A end = getCarriers()[1+SquarePlanar.TRANS_INDEX[i-1]];
+          CipRank begRank = new CipRank(getPriorityNumber(parts, beg), primes.get(beg));
+          CipRank endRank = new CipRank(getPriorityNumber(parts, end), primes.get(end));
+          if (sndAxisBeg == null ||
+              begRank.compareTo(sndAxisBeg) < 0 ||
+              begRank.equals(sndAxisBeg) && endRank.compareTo(sndAxisEnd) > 0) {
+            sndAxisBeg = begRank;
+            sndAxisEnd = endRank;
+          }
+        }
+
+        // now label like SP-4 (square planar)
+        cache.put(getFocus(), "SPY-5-" + axisRank + sndAxisEnd);
+      }
     }
 
     return Descriptor.ns;

--- a/core/src/main/java/com/simolecule/centres/config/Octahedral.java
+++ b/core/src/main/java/com/simolecule/centres/config/Octahedral.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An octahedral configuration is described by a focus and six carriers. The
@@ -119,12 +120,14 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
     A[] carriers = getCarriers();
     for (int i = 0; i < carriers.length; i++) {
       if (carriers[i].equals(atom)) {
-        return (A[]) new Object[]{
+        @SuppressWarnings("unchecked")
+        A[] plane = (A[]) new Object[]{
             carriers[PLANE_INDEX[i][0]],
             carriers[PLANE_INDEX[i][1]],
             carriers[PLANE_INDEX[i][2]],
             carriers[PLANE_INDEX[i][3]]
         };
+        return plane;
       }
     }
     throw new IllegalArgumentException();
@@ -142,10 +145,24 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
     throw new IllegalArgumentException();
   }
 
-  private boolean hasConfiguration(List<List<Edge<A, B>>> parts) {
-    return parts.size() > 2 ||
-           parts.size() == 2 &&
-           parts.get(0).size() != 1 && parts.get(0).size() != 5;
+  private boolean hasConfiguration(List<List<Edge<A, B>>> parts, Map<A,Integer> primes) {
+    if (parts.size() > 2 ||
+        parts.size() == 2 && parts.get(0).size() != 1 && parts.get(0).size() != 5) {
+      return true;
+    }
+
+    // check prime partitions
+    int numParts = parts.size();
+    for (List<Edge<A,B>> part : parts) {
+      for (int i=1; i<part.size(); i++) {
+        Integer primeA = primes.get(part.get(i-1).getEnd().getAtom());
+        Integer primeB = primes.get(part.get(i).getEnd().getAtom());
+        if (!Objects.equals(primeA, primeB))
+          numParts++;
+      }
+    }
+
+    return numParts > 2;
   }
 
   private Descriptor label(Node<A, B> root, SequenceRule<A, B> comp) {
@@ -155,38 +172,63 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
       return Descriptor.Unknown;
     List<List<Edge<A, B>>> parts    = comp.getSorter().getGroups(edges);
 
-    if (!hasConfiguration(parts))
+    // add on prime locants if not unique
+    Map<A,Integer> primes = new HashMap<>();
+
+    if (!priority.isUnique()) {
+
+      if (comp.getNumSubRules() == 3) {
+        // we are doing a preliminary pass and will
+        // revisit later one aux-descriptors are assigned
+        return Descriptor.Unknown;
+      }
+
+      assignPrimeLocants(parts, primes);
+    }
+
+    if (!hasConfiguration(parts, primes))
       return Descriptor.ns; // maybe return unknown?
 
-    A   fstAxisBeg = null;
-    int fstAxisBegRank = 0;
-    int fstAxisEndRank = 0;
-    int sndAxisBegRank;
-    int sndAxisEndRank;
-    int thdAxisBegRank;
-    int thdAxisEndRank;
+    A       fstAxisBeg = null;
+    CipRank fstAxisBegRank = null;
+    CipRank fstAxisEndRank = null;
+    CipRank sndAxisBegRank;
+    CipRank sndAxisEndRank;
+    CipRank thdAxisBegRank;
+    CipRank thdAxisEndRank;
 
+    // the first axis is select by starting from the highest priority ligand,
+    // if there are multiple we choose the axis going towards the lowest
+    // priority
     for (Edge<A, B> edge : parts.get(0)) {
       A   beg = edge.getEnd().getAtom();
       A   end = findTransAtom(beg);
-      int num = getPriorityNumber(parts, end);
-      if (num > fstAxisEndRank) {
-        fstAxisBegRank = getPriorityNumber(parts, beg);
-        fstAxisEndRank = num;
+      CipRank begRank = new CipRank(getPriorityNumber(parts, beg), primes.get(beg));
+      CipRank endRank = new CipRank(getPriorityNumber(parts, end), primes.get(end));
+      if (fstAxisBegRank != null && !begRank.equals(fstAxisBegRank))
+        break;
+      if (fstAxisEndRank == null ||
+          endRank.compareTo(fstAxisEndRank) > 0) {
+        fstAxisBegRank = begRank;
+        fstAxisEndRank = endRank;
         fstAxisBeg = beg;
       }
     }
 
-    List<Integer> ccw_plane = new ArrayList<>(4);
-    for (A a : getPlane(fstAxisBeg))
-      ccw_plane.add(getPriorityNumber(parts, a));
+    // get the ligands in the plan of the axis rotating counter-clockwise
+    List<CipRank> ccw_plane = new ArrayList<>(4);
+    for (A a : getPlane(fstAxisBeg)) {
+      CipRank r = new CipRank(getPriorityNumber(parts, a), primes.get(a));
+      ccw_plane.add(r);
+    }
 
+    // work out the second axis
     int low = 0;
     for (int i = 1; i < 4; i++) {
-      if (ccw_plane.get(i) < ccw_plane.get(low)) {
+      if (ccw_plane.get(i).compareTo(ccw_plane.get(low)) < 0) {
         low = i;
       } else if (ccw_plane.get(i).equals(ccw_plane.get(low)) &&
-                 ccw_plane.get((i + 2) % 4) > ccw_plane.get((low + 2) % 4)) {
+                 ccw_plane.get((i + 2) % 4).compareTo(ccw_plane.get((low + 2) % 4)) > 0) {
         low = i;
       }
     }
@@ -196,18 +238,22 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
     thdAxisBegRank = ccw_plane.get((low + 1) % 4);
     thdAxisEndRank = ccw_plane.get((low + 3) % 4);
 
-    int cmp = 0;
+    // suppress warnings
+    if (fstAxisEndRank == null)
+      return Descriptor.ns;
 
-    // don't need rotation if two axes are the same or if there is a symmetric axis
-    if (fstAxisEndRank != sndAxisEndRank &&
-        (fstAxisBegRank != fstAxisEndRank ||
-         sndAxisBegRank != sndAxisEndRank ||
-         thdAxisBegRank != thdAxisEndRank)) {
-      cmp = Integer.compare(ccw_plane.get((low + 1) % 4), ccw_plane.get((low + 4 - 1) % 4));
+    // check if we need rotation and what is.
+    // If two axis are the same or if there is a symmetric axis we don't need
+    // a rotation
+    int cmp = 0;
+    if (isAsymmetric(fstAxisBegRank, fstAxisEndRank,
+                     sndAxisBegRank, sndAxisEndRank,
+                     thdAxisBegRank, thdAxisEndRank)) {
+      cmp = ccw_plane.get((low + 1) % 4).compareTo(ccw_plane.get((low + 4 - 1) % 4));
       if (cmp == 0)
-        cmp = Integer.compare(ccw_plane.get((low + 1) % 4), ccw_plane.get((low + 4 - 1) % 4));
+        cmp = ccw_plane.get((low + 1) % 4).compareTo(ccw_plane.get((low + 4 - 1) % 4));
       if (cmp == 0)
-        cmp = Integer.compare(ccw_plane.get((low + 2) % 4), ccw_plane.get((low + 4 - 2) % 4));
+        cmp = ccw_plane.get((low + 2) % 4).compareTo(ccw_plane.get((low + 4 - 2) % 4));
     }
 
     final String rotate;
@@ -218,12 +264,24 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
     else
       rotate = "";
 
-    if (fstAxisEndRank < 7 && sndAxisEndRank < 7) {
-      cache.put(getFocus(), "OC-6-" + fstAxisEndRank + "" + sndAxisEndRank + rotate);
+    if (sndAxisEndRank != null) {
+      cache.put(getFocus(), "OC-6-" + fstAxisEndRank + sndAxisEndRank + rotate);
       return Descriptor.OC_6;
     }
 
     return Descriptor.ns;
+  }
+
+  private static boolean isAsymmetric(CipRank fstAxisBegRank,
+                                      CipRank fstAxisEndRank,
+                                      CipRank sndAxisBegRank,
+                                      CipRank sndAxisEndRank,
+                                      CipRank thdAxisBegRank,
+                                      CipRank thdAxisEndRank) {
+    return !fstAxisEndRank.equals(sndAxisEndRank) &&
+           (!fstAxisBegRank.equals(fstAxisEndRank) ||
+            !sndAxisBegRank.equals(sndAxisEndRank) ||
+            !thdAxisBegRank.equals(thdAxisEndRank));
   }
 
   @Override

--- a/core/src/main/java/com/simolecule/centres/config/Octahedral.java
+++ b/core/src/main/java/com/simolecule/centres/config/Octahedral.java
@@ -72,27 +72,27 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
 
   /* We are in normal form:
    *        c
-   *        | a
+   *        | f
    *        |/
    *    d---x---b = OH1
    *       /|       where a: first carrier, b: second carried, etc
-   *      f |             x: focus
+   *      a |             x: focus
    *        e             'a' is in front of the focus 'x', 'f' is behind
    *
    * storage index: a@0, b@1, c@2, d@3, e@4, f@5
    *
    * so if our axis is:
    *   a-f (0->5) the plane atoms are b,c,d,e (1,2,3,4) anticlockwise
-   *   b-d (1->3) the plane atoms are a,c,f,e (0,2,5,4) anticlockwise
-   *   c-e (2->4) the plane atoms are a,d,f,b (0,3,5,1) anticlockwise
+   *   b-d (1->3) the plane atoms are a,e,f,c (0,4,5,2) anticlockwise
+   *   c-e (2->4) the plane atoms are a,b,f,d (0,1,5,3) anticlockwise
    */
   private final int[][] PLANE_INDEX = new int[][]{
-      {1, 2, 3, 4}, // a-f
-      {0, 2, 5, 4}, // b-d
-      {0, 3, 5, 1}, // c-e
-      {4, 5, 2, 0}, // d-b
-      {1, 5, 3, 0}, // e-c
-      {4, 3, 2, 1}, // f-a
+      {1, 2, 3, 4}, // 0: a-f
+      {0, 4, 5, 2}, // 1: b-d
+      {0, 1, 5, 3}, // 2: c-e
+      {2, 5, 4, 0}, // 3: d-b
+      {3, 5, 1, 0}, // 4: e-c
+      {4, 3, 2, 1}, // 5: f-a
   };
 
   public Octahedral(A focus, A[] carriers) {

--- a/core/src/main/java/com/simolecule/centres/config/Octahedral.java
+++ b/core/src/main/java/com/simolecule/centres/config/Octahedral.java
@@ -304,23 +304,36 @@ public final class Octahedral<A, B> extends Configuration<A, B> {
         CipRank axisRank = new CipRank(getPriorityNumber(parts, axis), primes.get(axis));
 
         // note we are upside down so the plane is clockwise not anti-clockwise
-        CipRank sndAxisBeg = null;
-        CipRank sndAxisEnd = null;
+        List<CipRank> cw_plane = new ArrayList<>();
         for (int i=1; i<5; i++) {
           A beg = getCarriers()[i];
-          A end = getCarriers()[1+SquarePlanar.TRANS_INDEX[i-1]];
           CipRank begRank = new CipRank(getPriorityNumber(parts, beg), primes.get(beg));
-          CipRank endRank = new CipRank(getPriorityNumber(parts, end), primes.get(end));
+          cw_plane.add(begRank);
+        }
+
+        CipRank sndAxisBeg = null;
+        CipRank sndAxisEnd = null;
+        String rotation = "";
+        for (int i=0; i<4; i++) {
+          CipRank begRank = cw_plane.get(i);
+          CipRank endRank = cw_plane.get((i+2)%4);
           if (sndAxisBeg == null ||
               begRank.compareTo(sndAxisBeg) < 0 ||
               begRank.equals(sndAxisBeg) && endRank.compareTo(sndAxisEnd) > 0) {
             sndAxisBeg = begRank;
             sndAxisEnd = endRank;
+            rotation = "";
+
+            CipRank b = cw_plane.get((i+1)%4);
+            CipRank d = cw_plane.get((i+3)%4);
+            int cmp;
+            if ((cmp = b.compareTo(d)) != 0)
+              rotation = cmp < 0 ? "-C" : "-A";
           }
         }
 
         // now label like SP-4 (square planar)
-        cache.put(getFocus(), "SPY-5-" + axisRank + sndAxisEnd);
+        cache.put(getFocus(), "SPY-5-" + axisRank + sndAxisEnd + rotation);
       }
     }
 

--- a/core/src/main/java/com/simolecule/centres/config/SquarePlanar.java
+++ b/core/src/main/java/com/simolecule/centres/config/SquarePlanar.java
@@ -70,7 +70,7 @@ public final class SquarePlanar<A,B> extends Configuration<A,B> {
   private final Map<A,String> cache = new HashMap<>();
 
   // the index of the carrier in the trans position
-  private final int[] TRANS_INDEX = new int[]{2,3,0,1};
+  static final int[] TRANS_INDEX = new int[]{2,3,0,1};
 
   public SquarePlanar(A focus, A[] carriers)
   {

--- a/core/src/main/java/com/simolecule/centres/config/SquarePlanar.java
+++ b/core/src/main/java/com/simolecule/centres/config/SquarePlanar.java
@@ -35,8 +35,11 @@ import com.simolecule.centres.rules.Priority;
 import com.simolecule.centres.rules.SequenceRule;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * An square-planar configuration is described by a focus and four carriers. The
@@ -102,10 +105,24 @@ public final class SquarePlanar<A,B> extends Configuration<A,B> {
     throw new IllegalArgumentException();
   }
 
-  private boolean hasConfiguration(List<List<Edge<A,B>>> parts) {
-    return parts.size() > 2 ||
+  private boolean hasConfiguration(List<List<Edge<A,B>>> parts,
+                                   Map<A,Integer> primes) {
+    if (parts.size() > 2 ||
            parts.size() == 2 &&
-           parts.get(0).size() != 1 && parts.get(0).size() != 3;
+           parts.get(0).size() != 1 && parts.get(0).size() != 3) {
+      return true;
+    }
+    // check prime partitions
+    int numParts = parts.size();
+    for (List<Edge<A,B>> part : parts) {
+      for (int i=1; i<part.size(); i++) {
+        Integer primeA = primes.get(part.get(i-1).getEnd().getAtom());
+        Integer primeB = primes.get(part.get(i).getEnd().getAtom());
+        if (!Objects.equals(primeA, primeB))
+          numParts++;
+      }
+    }
+    return numParts > 2;
   }
 
   private Descriptor label(Node<A, B> root, SequenceRule<A, B> comp) {
@@ -113,23 +130,38 @@ public final class SquarePlanar<A,B> extends Configuration<A,B> {
     Priority              priority = comp.sort(root, edges);
     if (priority.wasWildcardFound())
       return Descriptor.Unknown;
-    List<List<Edge<A,B>>> parts    = comp.getSorter().getGroups(edges);
+    List<List<Edge<A,B>>> parts = comp.getSorter().getGroups(edges);
+    Map<A,Integer> primes = new HashMap<>();
 
-    if (!hasConfiguration(parts))
-      return Descriptor.ns; // maybe return unknown?
+    if (!priority.isUnique()) {
 
-    int low = 5;
+      // will be revisited
+      if (comp.getNumSubRules() == 3)
+        return Descriptor.Unknown;
+
+      assignPrimeLocants(parts, primes);
+
+//      if (!hasConfiguration(parts, primes))
+//        return Descriptor.ns;
+    }
+
+    CipRank axisBeg = null;
+    CipRank axisEnd = null;
     for (Edge<A,B> edge : parts.get(0)) {
       A beg = edge.getEnd().getAtom();
       A end = findTransAtom(beg);
-      int num = getPriorityNumber(parts, end);
-      if (num < low) {
-        low = num;
+      CipRank rankBeg = new CipRank(getPriorityNumber(parts, beg), primes.get(beg));
+      CipRank rankEnd = new CipRank(getPriorityNumber(parts, end), primes.get(end));
+      if (axisBeg != null && !rankEnd.equals(axisBeg))
+        continue;
+      if (axisEnd == null || rankEnd.compareTo(axisEnd) > 0) {
+        axisBeg = rankBeg;
+        axisEnd = rankEnd;
       }
     }
 
-    if (low < 5) {
-      cache.put(getFocus(), "SP-4-" + low);
+    if (axisEnd != null) {
+      cache.put(getFocus(), "SP-4-" + axisEnd);
       return Descriptor.SP_4;
     }
 

--- a/core/src/main/java/com/simolecule/centres/config/TrigonalBipyramidal.java
+++ b/core/src/main/java/com/simolecule/centres/config/TrigonalBipyramidal.java
@@ -34,6 +34,8 @@ import com.simolecule.centres.Node;
 import com.simolecule.centres.rules.Priority;
 import com.simolecule.centres.rules.SequenceRule;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,7 +101,17 @@ public final class TrigonalBipyramidal<A,B> extends Configuration<A,B> {
     Priority              priority = comp.sort(root, edges);
     if (priority.wasWildcardFound())
       return Descriptor.Unknown;
-    List<List<Edge<A,B>>> parts    = comp.getSorter().getGroups(edges);
+    List<List<Edge<A,B>>> parts = comp.getSorter().getGroups(edges);
+    Map<A,Integer> primes = new HashMap<>();
+
+    if (!priority.isUnique()) {
+      assignPrimeLocants(parts, primes);
+
+      // primes can change the order
+      edges = new ArrayList<>();
+      for (List<Edge<A,B>> part : parts)
+        edges.addAll(part);
+    }
 
     if (!hasConfiguration(parts))
       return Descriptor.ns; // maybe return unknown?
@@ -108,13 +120,46 @@ public final class TrigonalBipyramidal<A,B> extends Configuration<A,B> {
     for (Edge<A,B> edge : edges) {
       A beg = edge.getEnd().getAtom();
       A end = null;
-      if (beg.equals(carriers[0]))
+
+      CipRank[] equatorial = new CipRank[3];
+      if (beg.equals(carriers[0])) {
         end = carriers[4];
-      else if (beg.equals(carriers[4]))
+        equatorial = new CipRank[] {
+                new CipRank(getPriorityNumber(parts, carriers[1]), primes.get(carriers[1])),
+                new CipRank(getPriorityNumber(parts, carriers[2]), primes.get(carriers[2])),
+                new CipRank(getPriorityNumber(parts, carriers[3]), primes.get(carriers[3]))
+        };
+      }
+      else if (beg.equals(carriers[4])) {
         end = carriers[0];
+        equatorial = new CipRank[] {
+                new CipRank(getPriorityNumber(parts, carriers[3]), primes.get(carriers[3])),
+                new CipRank(getPriorityNumber(parts, carriers[2]), primes.get(carriers[2])),
+                new CipRank(getPriorityNumber(parts, carriers[1]), primes.get(carriers[1]))
+        };
+      }
       if (end != null) {
-        cache.put(getFocus(), "TBPY-5-" + getPriorityNumber(parts, beg)
-                              + "" + getPriorityNumber(parts, end));
+
+        String rotate = "";
+        if (!equatorial[0].equals(equatorial[1]) &&
+            !equatorial[0].equals(equatorial[2]) &&
+            !equatorial[1].equals(equatorial[2])) {
+          // find the lowest
+          int off = 0;
+          for (int i = 1; i < equatorial.length; i++) {
+            if (equatorial[i].compareTo(equatorial[off]) < 0)
+              off = i;
+          }
+          if (equatorial[off].compareTo(equatorial[(off+1)%equatorial.length]) < 0 &&
+              equatorial[(off+1)%equatorial.length].compareTo(equatorial[(off+2)%equatorial.length]) < 0)
+            rotate = "-A";
+          else
+            rotate = "-C";
+        }
+
+        cache.put(getFocus(), "TBPY-5-" + new CipRank(getPriorityNumber(parts, beg), primes.get(beg))
+                              + new CipRank(getPriorityNumber(parts, end), primes.get(end)) +
+                              rotate);
         return Descriptor.TBPY_5;
       }
     }

--- a/opsin/pom.xml
+++ b/opsin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>centres</artifactId>
     <groupId>com.simolecule.centres</groupId>
-    <version>1.4</version>
+    <version>1.5-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.simolecule.centres</groupId>
   <artifactId>centres</artifactId>
-  <version>1.4</version>
+  <version>1.5-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>core</module>


### PR DESCRIPTION
- Fix a bug with C/A winding of octahedrals
- Add support from prime ligands allowing labelling of bidentane ligands.
- Add C/A for TBPY
- Add support for degenerate configs of OC-6 -> SP-4 (square planar) + SPY-5 (square pyramidal) 